### PR TITLE
change restsharp dependency version to 2.4

### DIFF
--- a/nuget/RestSharp.Portable.Hal.nuspec
+++ b/nuget/RestSharp.Portable.Hal.nuspec
@@ -19,12 +19,12 @@
       
       <group targetFramework="portable-net45+win+wpa81+wp80+MonoAndroid10+xamarinios10+MonoTouch10">
         <dependency id="FSharp.Core" version="3.1.2.1" />
-        <dependency id="FubarCoder.RestSharp.Portable" version="2.2.0" />
+        <dependency id="FubarCoder.RestSharp.Portable" version="2.4.0" />
       </group>
 
       <group>
         <dependency id="FSharp.Core" version="4.3.1.0" />
-        <dependency id="FubarCoder.RestSharp.Portable" version="2.2.0" />
+        <dependency id="FubarCoder.RestSharp.Portable" version="2.4.0" />
       </group>
       
     </dependencies>


### PR DESCRIPTION
NuGet dependency version is currently 2.2
However, the project reference is 2.4
This means  if you add the NuGet package to a project it will throw an error when you new up a HalClientFactory :

Could not load file or assembly 'RestSharp.Portable, Version=2.4.0.0, Culture=neutral, PublicKeyToken=be81bb0f53eab22f' or one of its dependencies. The located assembly's manifest definition does not match the assembly reference. 

also, need to publish to NuGet with the correct version 
